### PR TITLE
Update sscce.js

### DIFF
--- a/src/sscce.js
+++ b/src/sscce.js
@@ -24,6 +24,11 @@ module.exports = async function() {
     });
     const Foo = sequelize.define('Foo', { name: DataTypes.TEXT });
     await sequelize.sync();
-    log(await Foo.create({ name: 'foo' }));
-    expect(await Foo.count()).to.equal(1);
+    
+    const foobar = await Foo.create({ name: 'bar' });
+    const foobiz = await Foo.create({ name: 'biz' });
+  
+    await foobar.reload({ where: { name: 'biz' } });
+  
+    console.log(foobar.name); //  biz
 };


### PR DESCRIPTION
This sample tries to showcase the issue. 

Reloading an instance using `options.where` causes the root where clause `this.where()` to be lost which may lead to reloading a different instance and cause critical issues as you are no longer have the entity you may think you have.