### PR TITLE
Scopes with sequelize "Or" operators

### DIFF
--- a/src/sscce.js
+++ b/src/sscce.js
@@ -24,26 +24,26 @@ module.exports = async function() {
         }
     });
     const identity = (arg) => arg;
-    const Foo = sequelize.define('Foo', { name: DataTypes.TEXT, id: DataTypes.INTEGER }, {
+    const Foo = sequelize.define('Foo', { name: DataTypes.TEXT, number: DataTypes.INTEGER }, {
       scopes: {
         identityScope: identity,
         altIdentityScope: identity,
       }
     });
     await sequelize.sync();
-    log(await Foo.create({ name: 'foo', id: 10 }));
-    log(await Foo.create({ name: 'bar', id: 100 }));
-    log(await Foo.create({ name: 'bar', id: 2 }));
-    log(await Foo.create({ name: 'foo', id: 1 }));
+    log(await Foo.create({ name: 'foo', number: 10 }));
+    log(await Foo.create({ name: 'bar', number: 100 }));
+    log(await Foo.create({ name: 'bar', number: 2 }));
+    log(await Foo.create({ name: 'foo', number: 1 }));
     const scopes = [];
     scopes.push(['identityScope', {
       where: {
-        [Op.or]: [{ id: 2 }, { id: 1 }]
+        [Op.or]: [{ number: 2 }, { number: 1 }]
       }
     }]);
     scopes.push(['altIdentityScope', { where: { name: 'bar' } }]);
     const ScopedFoo = Foo.scope(scopes);
     expect(await ScopedFoo.count()).to.equal(1);
     const results = await ScopedFoo.findAll();
-    expect(results[0].id).to.equal(2);
+    expect(results[0].number).to.equal(2);
 };

--- a/src/sscce.js
+++ b/src/sscce.js
@@ -36,7 +36,11 @@ module.exports = async function() {
     log(await Foo.create({ name: 'bar', id: 2 }));
     log(await Foo.create({ name: 'foo', id: 1 }));
     const scopes = [];
-    scopes.push(['identityScope', { where: { [Op.or]: [{ id: 2 }, { id: 1 }] } });
+    scopes.push(['identityScope', {
+      where: {
+        [Op.or]: [{ id: 2 }, { id: 1 }]
+      }
+    }]);
     scopes.push(['altIdentityScope', { where: { name: 'bar' } }]);
     const ScopedFoo = Foo.scope(scopes);
     expect(await ScopedFoo.count()).to.equal(1);


### PR DESCRIPTION
adding scopes with sequelize "Or" operators will ignore the entire where clause with the "Or" operator when it is passed in as a plain JS object.

Still double checking if this will reproduce the error I saw in my usage, let's see what CI says