### PR TITLE
sscce for underscore column issue introduced by 1a16b91

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "is-plain-object": "^3",
     "json-stringify-safe": "^5",
     "lodash.defaults": "^4",
-    "sequelize": "^6",
+    "sequelize": "^6.6.5",
     "sinon": "^9",
     "sinon-chai": "^3"
   },

--- a/src/sscce.js
+++ b/src/sscce.js
@@ -1,36 +1,66 @@
-'use strict';
+"use strict";
 
 // Require the necessary things from Sequelize
-const { Sequelize, Op, Model, DataTypes } = require('sequelize');
+const { Sequelize, Op, Model, DataTypes } = require("sequelize");
 
 // This function should be used instead of `new Sequelize()`.
 // It applies the config for your SSCCE to work on CI.
-const createSequelizeInstance = require('./utils/create-sequelize-instance');
+const createSequelizeInstance = require("./utils/create-sequelize-instance");
 
 // This is an utility logger that should be preferred over `console.log()`.
-const log = require('./utils/log');
+const log = require("./utils/log");
 
 // You can use sinon and chai assertions directly in your SSCCE if you want.
-const sinon = require('sinon');
-const { expect } = require('chai');
+const sinon = require("sinon");
+const { expect } = require("chai");
 
 // Your SSCCE goes inside this function.
-module.exports = async function() {
+module.exports = async function () {
   const sequelize = createSequelizeInstance({
     logQueryParameters: true,
     benchmark: true,
     define: {
-      timestamps: false // For less clutter in the SSCCE
-    }
+      timestamps: false, // For less clutter in the SSCCE
+    },
   });
 
-  const Foo = sequelize.define('Foo', { name: DataTypes.TEXT });
+  const Participation = sequelize.define(
+    "Participation",
+    {
+      userId: { field: "user_id", type: DataTypes.INTEGER, allowNull: false },
+      campaignId: {
+        field: "campaign_id",
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      comment: {
+        field: "comment",
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    },
+    {
+      timestamps: true,
+      paranoid: false,
+    }
+  );
+
+  // No primary key attribute
+  Participation.removeAttribute("id");
 
   const spy = sinon.spy();
   sequelize.afterBulkSync(() => spy());
   await sequelize.sync();
   expect(spy).to.have.been.called;
 
-  log(await Foo.create({ name: 'foo' }));
-  expect(await Foo.count()).to.equal(1);
+  log(await Participation.create({ userId: 1, campaignId: 1 }));
+  expect(await Participation.count()).to.equal(1);
+
+  const p = await Participation.findOne({
+    where: { userId: 1, campaignId: 1 },
+  });
+
+  p.comment = "Updated campaign";
+
+  expect(await p.save()).not.to.throw; // Boom
 };


### PR DESCRIPTION
In this scenario there is a table with underscore columns that does not have a primary key. When a model is saved, the generated sql for the update tries to use the camelCase attribute names instead of the underscored column names. The resulting error is
```
Error: SQLITE_ERROR: no such column: userId
```
This issue was introduced in sequelize@6.6.4. Prior versions did not have this issue.