### PR TITLE
Reproduce a bug with enums using schemas in pg

### DIFF
--- a/src/sscce.js
+++ b/src/sscce.js
@@ -14,8 +14,12 @@ const log = require('./utils/log');
 const sinon = require('sinon');
 const { expect } = require('chai');
 
+class BookDetails extends Sequelize.Model {}
+
 // Your SSCCE goes inside this function.
 module.exports = async function() {
+  if (process.env.DIALECT !== "postgres") return;
+
   const sequelize = createSequelizeInstance({
     logQueryParameters: true,
     benchmark: true,
@@ -24,13 +28,40 @@ module.exports = async function() {
     }
   });
 
-  const Foo = sequelize.define('Foo', { name: DataTypes.TEXT });
+  BookDetails.init({
+    uniqueName: {
+        type: Sequelize.DataTypes.STRING(100),
+        unique: true,
+        allowNull: false,
+        primaryKey: true
+    },
+    originalCategories: {
+        type: Sequelize.DataTypes.ARRAY(Sequelize.DataTypes.ENUM({
+          values: ['drama', 'comedy'],
+        })),
+      },
+  }, {
+      underscored: true,
+      modelName: 'BookDetails',
+      schema: 'test',
+      sequelize
+  });
+  await BookDetails.sync({force: true});
 
-  const spy = sinon.spy();
-  sequelize.afterBulkSync(() => spy());
-  await sequelize.sync();
-  expect(spy).to.have.been.called;
+  /* bulkCreate tries to execute this query:
+  INSERT INTO "test"."book_details" ("unique_name","original_categories") VALUES ('test',ARRAY['drama']::"enum_test.book_details_original_categories"[]) RETURNING "unique_name","original_categories";
+  when it should execute this:
+  INSERT INTO "test"."book_details" ("unique_name","original_categories") VALUES ('test',ARRAY['drama']::"test"."enum_book_details_original_categories"[]) RETURNING "unique_name","original_categories";
+  as the array enum type is not called "enum_test.book_details_originalCategories" but "test"."enum_book_details_original_categories" the insert query fails.
+  */
+  await BookDetails.bulkCreate([{
+      uniqueName: 'test',
+      originalCategories: ['drama']
+  }]);
 
-  log(await Foo.create({ name: 'foo' }));
-  expect(await Foo.count()).to.equal(1);
+  /* The issue is that when sequelize generates the enum name is not considering that enums can be inside a schema, and tries to use the full
+  name of the object (schema).(table) and adds enum_ at the begining and this is not the logic used for creating the initial value of the enum
+  if there is a schema present it should only add enum_ to the table name and use the schema for reference at the begining of the type */
+
+  expect(await BookDetails.count()).to.equal(1);
 };


### PR DESCRIPTION
- Create a simple model that uses a schema on the database instead of public
- The model must have a property that is an array of enums
- Run a bulkCreate